### PR TITLE
Add contact email handler and chatbot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+EMAIL_USER=your-email@example.com
+EMAIL_PASS=your-email-password

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "^15.2.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.14",

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import nodemailer from 'nodemailer';
+
+export async function POST(req: Request) {
+  const { name, email, subject, message } = await req.json();
+
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
+    },
+  });
+
+  const mailOptions = {
+    from: `"${name}" <${email}>`,
+    to: 'kihiujohn12@gmail.com',
+    subject,
+    text: message,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error sending email', error);
+    return NextResponse.json({ success: false }, { status: 500 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import { Inter } from 'next/font/google';
 import type { Metadata } from 'next';
+import Chatbot from '@/components/Chatbot';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -25,6 +26,7 @@ export default function RootLayout({
       </head>
       <body className="min-h-screen antialiased">
         {children}
+        <Chatbot />
       </body>
     </html>
   );

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { useState } from 'react';
+
+const items = [
+  'Responsive Websites',
+  'E-commerce Platforms',
+  'Landing Pages',
+  'Portfolio Sites',
+  'Web Applications',
+];
+
+const Chatbot = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      {open && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg w-72 p-4 mb-2 animate-fade-in">
+          <p className="font-medium mb-2">How can I help you?</p>
+          <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            Here are some things I can build for your website:
+          </p>
+          <ul className="list-disc list-inside space-y-1 text-sm text-gray-700 dark:text-gray-200">
+            {items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <button
+        onClick={() => setOpen(!open)}
+        className="bg-primary-600 hover:bg-primary-700 text-white rounded-full p-3 focus-ring"
+        aria-label="Toggle Chatbot"
+      >
+        {open ? (
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        ) : (
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default Chatbot;

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,8 +1,40 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 const Contact = () => {
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    subject: '',
+    message: '',
+  });
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus(null);
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setStatus('Message sent successfully.');
+        setForm({ name: '', email: '', subject: '', message: '' });
+      } else {
+        setStatus('Failed to send message.');
+      }
+    } catch (err) {
+      setStatus('Failed to send message.');
+    }
+  };
+
   return (
     <section id="contact" className="section-padding bg-gray-50 dark:bg-gray-800">
       <div className="container mx-auto px-4 md:px-6">
@@ -16,7 +48,7 @@ const Contact = () => {
 
         <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
           <div className="bg-white dark:bg-gray-700 rounded-lg shadow-md p-6 md:p-8">
-            <form className="space-y-6">
+            <form className="space-y-6" onSubmit={handleSubmit}>
               <div>
                 <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Your Name
@@ -25,6 +57,8 @@ const Contact = () => {
                   type="text"
                   id="name"
                   name="name"
+                  value={form.name}
+                  onChange={handleChange}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-primary-600 focus:border-transparent dark:bg-gray-800 dark:text-white"
                   placeholder="John Doe"
                   required
@@ -39,6 +73,8 @@ const Contact = () => {
                   type="email"
                   id="email"
                   name="email"
+                  value={form.email}
+                  onChange={handleChange}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-primary-600 focus:border-transparent dark:bg-gray-800 dark:text-white"
                   placeholder="john@example.com"
                   required
@@ -53,6 +89,8 @@ const Contact = () => {
                   type="text"
                   id="subject"
                   name="subject"
+                  value={form.subject}
+                  onChange={handleChange}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-primary-600 focus:border-transparent dark:bg-gray-800 dark:text-white"
                   placeholder="Project Inquiry"
                   required
@@ -67,6 +105,8 @@ const Contact = () => {
                   id="message"
                   name="message"
                   rows={4}
+                  value={form.message}
+                  onChange={handleChange}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-primary-600 focus:border-transparent dark:bg-gray-800 dark:text-white"
                   placeholder="Tell me about your project..."
                   required
@@ -79,6 +119,9 @@ const Contact = () => {
               >
                 Send Message
               </button>
+              {status && (
+                <p className="text-sm mt-2 text-center text-gray-600 dark:text-gray-300">{status}</p>
+              )}
             </form>
           </div>
 


### PR DESCRIPTION
## Summary
- add `nodemailer` dependency
- provide `.env.example` for email credentials
- implement `/api/contact` POST route to send emails
- enhance contact form with submission logic
- add floating Chatbot component listing available services
- include Chatbot globally in the layout

## Testing
- `bun run build` *(fails: next not installed)*
- `bun run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e89c9e4d4832fb4ffbda417d90335