### PR TITLE
Fix nodemailer entry missing from lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^15.2.3",
+        "nodemailer": "^6.9.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -2110,6 +2111,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",


### PR DESCRIPTION
## Summary
- update `package-lock.json` so `npm ci` succeeds

## Testing
- `bun run build` *(fails: failed to fetch font from fonts.googleapis.com)*
- `npm run build` *(fails: failed to fetch font from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684ea005d838832fb64414bec9d35330